### PR TITLE
update buf-tour to use the new plugin key

### DIFF
--- a/finish/buf.gen.yaml
+++ b/finish/buf.gen.yaml
@@ -6,10 +6,10 @@ managed:
     except:
       - buf.build/googleapis/googleapis
 plugins:
-  - name: go
+  - plugin: go
     out: gen/proto/go
     opt: paths=source_relative
-  - name: go-grpc
+  - plugin: go-grpc
     out: gen/proto/go
     opt:
       - paths=source_relative


### PR DESCRIPTION
Update the tour to use the new 'plugin' key which can be used for both remote and local generation.