### PR TITLE
Remove buf.work.yaml for now

### DIFF
--- a/.github/workflows/CONTRIBUTING.md
+++ b/.github/workflows/CONTRIBUTING.md
@@ -11,8 +11,6 @@ Ensure that the module you plan on syncing has been created in the BSR. For exam
 
 ### Set the module up with the [buf-push-action](https://github.com/bufbuild/buf-push-action)
 
-Ensure that your module is included in the `start` directory [workspace](../../start/buf.work.yaml). You can ensure that you have correctly set up the module in the workspace by running `buf build` from the `start` directory.
-
 Add the new module to the [buf workflow](../workflows/buf.yaml), similarly to how the tutorial-breaking module is configured there. For example, if you were adding a `tutorial-foo` module with its protobuf files defined in a `proto` subdirectory, you'd add the following clause to the workflow:
 ```
       # Push the tutorial-foo module

--- a/start/buf.work.yaml
+++ b/start/buf.work.yaml
@@ -1,3 +1,0 @@
-version: v1
-directories:
-  - tutorial-breaking/proto


### PR DESCRIPTION
The buf.work.yaml is not strictly necessary for our current workflows, we can re-add later if it helps us