### PR TITLE
Update connect package import in BSR example server

### DIFF
--- a/start/getting-started-with-bsr/server/main.go
+++ b/start/getting-started-with-bsr/server/main.go
@@ -8,7 +8,7 @@ import (
 
 	petv1 "github.com/bufbuild/buf-tour/gen/pet/v1"
 	"github.com/bufbuild/buf-tour/gen/pet/v1/petv1connect"
-	"github.com/bufbuild/connect-go"
+	connect "connectrpc.com/connect"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )


### PR DESCRIPTION
👋 Greetings Buf team!

I was following along with the guide to try out the BSR and hit a snag when it came to running the server:
```
server/main.go:20:58: cannot use &petStoreServiceServer{} (value of type *petStoreServiceServer) as petv1connect.PetStoreServiceHandler value in argument to petv1connect.NewPetStoreServiceHandler: *petStoreServiceServer does not implement petv1connect.PetStoreServiceHandler (wrong type for method PutPet)
		have PutPet(context.Context, *"github.com/bufbuild/connect-go".Request[petv1.PutPetRequest]) (*"github.com/bufbuild/connect-go".Response[petv1.PutPetResponse], error)
		want PutPet(context.Context, *"connectrpc.com/connect".Request[petv1.PutPetRequest]) (*"connectrpc.com/connect".Response[petv1.PutPetResponse], error)
```

From the type mismatch in the error, I identified that the `connect` package being imported and used in `start/.../server/main.go` doesn't seem to match that in the generated `pet.connect.go` file.

I saw that this sort of update had [already been made](https://github.com/courier-new/buf-tour/commit/d4bf43ef9c6ec6da128de06578c6c7d74fadff33#diff-ca46d42fbc538116b7bcc67e4436b4a3d864a4854908a07e5fbf02ec892370d7) in the corresponding `finish/.../server/main.go`, so I assume it was just an oversight that it wasn't also changed here. 🙂

Double-checked and did not see any other instances of the outdated package in the repo. `go.mod` is [already up-to-date](https://github.com/bufbuild/buf-tour/blob/main/start/getting-started-with-bsr/go.mod#L6) on this!